### PR TITLE
Fix type error at runtime

### DIFF
--- a/lib/otp.dart
+++ b/lib/otp.dart
@@ -90,13 +90,13 @@ class OTP {
   /// Generates a cryptographically secure random secret in base32 string format.
   static String randomSecret() {
     var rand = Random.secure();
-    var bytes = List();
+    var bytes = <int>[];
 
-    for (int i = 0; i < 10; i++) {
+    for (var i = 0; i < 10; i++) {
       bytes.add(rand.nextInt(256));
     }
 
-    return base32.encode(bytes);
+    return base32.encode(Uint8List.fromList(bytes));
   }
 
   static Uint8List _int2bytes(int long) {

--- a/test/otp_test.dart
+++ b/test/otp_test.dart
@@ -64,6 +64,11 @@ main() {
 
       expect(OTP.constantTimeVerification(code, othercode), equals(true));
     });
+    
+    test('Generate a cryptographically secure random secret in base32 string format', () {
+      var secret = OTP.randomSecret();
+      assert(secret.isNotEmpty);
+    });
 
     test('Verify comparison timing', () {
       var code = OTP.generateTOTPCodeString("JBSWY3DPEHPK3PXZ", TIME);


### PR DESCRIPTION
`randomSecret()` method generates the following error at runtime after `base32.encode` changed its parameter type on the latest version.

```
type 'List<dynamic>' is not a subtype of type 'Uint8List'
```

Fix the issue by using the appropriate constructor from `Uint8List`
