### PR TITLE
correctly pass isGoogle to generator methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+v2.2.0+1
+- Correctly use Google Auth flag (`isGoogle`) to disable padding.
+
 v2.2.0
 - Add Google Auth flag, because they do SHA1 TOTP without Padding the secret.
 - Reverting _int2bytes function back to old implementation, as the new on uses int64 which breaks flutter web and dart2js as it doesn't have support for Int64.

--- a/lib/otp.dart
+++ b/lib/otp.dart
@@ -21,10 +21,11 @@ class OTP {
   static int generateTOTPCode(String secret, int time,
       {int length = 6,
       int interval = 30,
-      Algorithm algorithm = Algorithm.SHA256, bool isGoogle = false}) {
+      Algorithm algorithm = Algorithm.SHA256,
+      bool isGoogle = false}) {
     time = (((time ~/ 1000).round()) ~/ interval).floor();
     return _generateCode(secret, time, length, getAlgorithm(algorithm),
-        _getAlgorithmByteLength(algorithm));
+        _getAlgorithmByteLength(algorithm), isGoogle: isGoogle);
   }
 
   /// Generates a Time-based one time password code and return as a 0 padded string.
@@ -37,9 +38,10 @@ class OTP {
   static String generateTOTPCodeString(String secret, int time,
       {int length = 6,
       int interval = 30,
-      Algorithm algorithm = Algorithm.SHA256, bool isGoogle = false}) {
+      Algorithm algorithm = Algorithm.SHA256,
+      bool isGoogle = false}) {
     var code =
-        '${generateTOTPCode(secret, time, length: length, interval: interval, algorithm: algorithm)}';
+        '${generateTOTPCode(secret, time, length: length, interval: interval, algorithm: algorithm, isGoogle: isGoogle)}';
     return code.padLeft(length, '0');
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: otp
-version: 2.2.0
+version: 2.2.0+1
 description: RFC6238 Time-Based One-Time Password / Google Authenticator Library
 homepage: https://github.com/Daegalus/dart-otp
 environment:

--- a/test/otp_test.dart
+++ b/test/otp_test.dart
@@ -35,6 +35,16 @@ void main() {
       expect(code, equals(449891));
     });
 
+    test('Verify isGoogle is passed along to disable padding', () {
+      var code = OTP.generateTOTPCodeString(
+        'Q4D65VKZ3T5NERSB',
+        1589633445440,
+        algorithm: Algorithm.SHA1,
+        isGoogle: true,
+      );
+      expect(code, equals('700998'));
+    });
+
     test(
         'Generated code for Sun Mar 03 09:22:30 2013 +0000 using SHA1 (old default)',
         () {


### PR DESCRIPTION
the `isGoogle` flag had no effect whatsoever :-)
I have verified the test with https://totp.danhersam.com/ - which seems to add no padding for SHA-1 as well.