### PR TITLE
Allow lowercase base32 strings if isGoogle is set to true

### DIFF
--- a/lib/otp.dart
+++ b/lib/otp.dart
@@ -95,7 +95,7 @@ class OTP {
 
     var secretList = Uint8List.fromList(utf8.encode(secret));
     if (isGoogle) {
-      secretList = base32.decode(secret);
+      secretList = base32.decode(secret.toUpperCase());
     }
 
     if (!isGoogle && (!isHOTP || useTOTPPaddingForHOTP)) {

--- a/test/otp_test.dart
+++ b/test/otp_test.dart
@@ -332,6 +332,18 @@ void main() {
 
         expect(code, equals(token), reason: 'TOTP eq rfc dataset');
       });
+
+      test('Allow lowercase Base32 string if isGoogle is set to true', () {
+        final code = OTP.generateTOTPCodeString(
+          'kzvvz2s2ylhdmxzk',
+          1679772523111,
+          algorithm: Algorithm.SHA1,
+          interval: 30,
+          length: 6,
+          isGoogle: true,
+        );
+        expect(code, equals('869063'));
+      });
     }
   });
 }


### PR DESCRIPTION
This PR adds support for lower-case Base32 strings to match the behaviour of Google Authenticator.
`_generateCode` function now always converts strings to upper-case if `isGoogle` is set to true before calling `base32.decode`.

Tested this by importing the key provided in #44 to Google Authentication and checking if it generates the same codes for lower and uppercase secret.

Fixes #44 and #45.